### PR TITLE
BREAKING CHANGE: Post testing cleanup

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -7,32 +7,26 @@ import { Stack } from './Stack';
 
 export interface BottomNavigationProps extends BoxProps<'nav'> {
   items?: NavigationItemItem[];
-  onSelectedNameChange: (name: string, e: MouseEvent<HTMLElement>) => void;
-  selectedName?: string;
+  onValueChange: (value: string, e: MouseEvent<HTMLElement>) => void;
+  value?: string;
 }
 
 export const BottomNavigation = forwardRef<HTMLElement, BottomNavigationProps>(
   function BottomNavigation(props, ref) {
-    const {
-      items = [],
-      onSelectedNameChange,
-      selectedName,
-      sx,
-      ...rest
-    } = props;
+    const { items = [], onValueChange, sx, value, ...rest } = props;
 
     const getIsSelected = useCallback<(item: NavigationItemItem) => boolean>(
-      ({ name }) => name === selectedName,
-      [selectedName],
+      item => item.value === value,
+      [value],
     );
 
     const handleItemSelect = useCallback<
       (item: NavigationItemItem, e: MouseEvent<HTMLElement>) => void
     >(
-      ({ name }, e) => {
-        onSelectedNameChange(name, e);
+      (item, e) => {
+        onValueChange(item.value, e);
       },
-      [onSelectedNameChange],
+      [onValueChange],
     );
 
     return (

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -2,29 +2,35 @@ import React, { forwardRef, MouseEvent, useCallback } from 'react';
 
 import { mergeSX } from '../helpers';
 import { Box, BoxProps } from './Box';
-import { NavigationItem, NavigationItemItem } from './NavigationItem';
+import {
+  NavigationItem,
+  NavigationItemItem,
+  NavigationItemOnSelect,
+  NavigationItemValue,
+} from './NavigationItem';
 import { Stack } from './Stack';
 
 export interface BottomNavigationProps extends BoxProps<'nav'> {
   items?: NavigationItemItem[];
-  onValueChange: (value: string, e: MouseEvent<HTMLElement>) => void;
-  value?: string;
+  onValueChange: (
+    value: NavigationItemValue,
+    e: MouseEvent<HTMLElement>,
+  ) => void;
+  value?: NavigationItemValue;
 }
 
 export const BottomNavigation = forwardRef<HTMLElement, BottomNavigationProps>(
   function BottomNavigation(props, ref) {
     const { items = [], onValueChange, sx, value, ...rest } = props;
 
-    const getIsSelected = useCallback<(item: NavigationItemItem) => boolean>(
-      item => item.value === value,
+    const getIsSelected = useCallback<(item: NavigationItemValue) => boolean>(
+      itemValue => itemValue === value,
       [value],
     );
 
-    const handleItemSelect = useCallback<
-      (item: NavigationItemItem, e: MouseEvent<HTMLElement>) => void
-    >(
-      (item, e) => {
-        onValueChange(item.value, e);
+    const handleItemSelect = useCallback<NavigationItemOnSelect>(
+      (selectedValue, e) => {
+        onValueChange(selectedValue, e);
       },
       [onValueChange],
     );
@@ -48,14 +54,16 @@ export const BottomNavigation = forwardRef<HTMLElement, BottomNavigationProps>(
         <Stack direction="row" sx={{ maxWidth: 480, width: '100%' }}>
           {items.map((item, index) => (
             <NavigationItem
-              isSelected={getIsSelected(item)}
-              item={item}
+              icon={item.icon}
+              label={item.label}
+              isSelected={getIsSelected(item.value)}
               key={`${item.label}${index}`}
               onSelect={handleItemSelect}
               sx={{
                 flexBasis: `${(1 / items.length) * 100}%`,
                 label: 'BottomNavigationItem',
               }}
+              value={item.value}
             />
           ))}
         </Stack>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -93,7 +93,7 @@ export const Button = forwardRef<
         justifyContent: 'center',
         label: 'Button',
         minWidth: text ? theme.space(6) : undefined,
-        opacity: disabled ? 0.5 : undefined,
+        opacity: disabled ? theme.disabledOpacity : undefined,
         outline: 'none',
         position: 'relative',
         '&::after': {

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -75,7 +75,7 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(
           {
             cursor: disabled ? 'not-allowed' : 'pointer',
             label: 'Checkbox',
-            opacity: disabled ? 0.5 : 1,
+            opacity: disabled ? theme.disabledOpacity : undefined,
             outline: 'none',
           },
           sx,

--- a/src/components/FormGroup.tsx
+++ b/src/components/FormGroup.tsx
@@ -1,10 +1,12 @@
 import React, { forwardRef, Ref } from 'react';
 
 import { mergeSX } from '../helpers';
+import { useThemeWithDefault } from '../hooks';
 import { Stack, StackProps } from './Stack';
 import { Text } from './Text';
 
 export interface FormGroupProps extends Omit<StackProps, 'ref'> {
+  disabled?: boolean;
   element?: 'div' | 'fieldset';
   error?: string;
   htmlFor?: string;
@@ -18,6 +20,7 @@ export const FormGroup = forwardRef<HTMLElement, FormGroupProps>(
   function FormGroup(props, ref) {
     const {
       children,
+      disabled,
       element = 'fieldset',
       error,
       htmlFor,
@@ -29,6 +32,11 @@ export const FormGroup = forwardRef<HTMLElement, FormGroupProps>(
       warning,
       ...rest
     } = props;
+    const theme = useThemeWithDefault();
+
+    const disabledProps = disabled
+      ? { sx: { opacity: theme.disabledOpacity } }
+      : {};
 
     return (
       <Stack
@@ -44,7 +52,7 @@ export const FormGroup = forwardRef<HTMLElement, FormGroupProps>(
         {...rest}
       >
         {(label || secondaryLabel) && (
-          <Stack space={2.5}>
+          <Stack space={2.5} {...disabledProps}>
             {label && (
               <Text element="label" htmlFor={htmlFor} variant="label">
                 {label}
@@ -64,7 +72,7 @@ export const FormGroup = forwardRef<HTMLElement, FormGroupProps>(
         )}
         {children}
         {(error || success || warning) && (
-          <Stack space={2.5}>
+          <Stack space={2.5} {...disabledProps}>
             {error && (
               <Text color="error" variant="helper">
                 {error}

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, Ref } from 'react';
 
 import { mergeSX } from '../helpers';
+import { useThemeWithDefault } from '../hooks';
 import { Box, BoxProps } from './Box';
 import { Icon, IconProps } from './Icon';
 
@@ -28,6 +29,7 @@ export const IconButton = forwardRef<
     sx,
     ...rest
   } = props;
+  const theme = useThemeWithDefault();
 
   const elementProps = element === 'button' ? { disabled } : {};
 
@@ -48,7 +50,7 @@ export const IconButton = forwardRef<
           cursor: disabled ? 'not-allowed' : undefined,
           flex: 0,
           label: 'IconButton',
-          opacity: disabled ? 0.5 : undefined,
+          opacity: disabled ? theme.disabledOpacity : undefined,
           outline: 'none',
         },
         sx,

--- a/src/components/NavigationItem.tsx
+++ b/src/components/NavigationItem.tsx
@@ -13,28 +13,36 @@ import { MotionBox } from './MotionBox';
 import { Stack } from './Stack';
 import { Text } from './Text';
 
+export type NavigationItemValue = number | string;
+
 export interface NavigationItemItem {
   icon: ReactElement;
   label?: string;
-  value: string;
+  value: NavigationItemValue;
 }
 
+export type NavigationItemOnSelect = (
+  selectedValue: NavigationItemValue,
+  e: MouseEvent<HTMLElement>,
+) => void;
+
 export interface NavigationItemProps extends Omit<BoxProps<'li'>, 'onSelect'> {
+  icon: ReactElement;
   isSelected?: boolean;
-  item: NavigationItemItem;
-  onSelect?: (item: NavigationItemItem, e: MouseEvent<HTMLElement>) => void;
+  label?: string;
+  value: NavigationItemValue;
+  onSelect?: NavigationItemOnSelect;
 }
 
 export const NavigationItem = forwardRef<HTMLLIElement, NavigationItemProps>(
   function NavigationItem(props, ref) {
-    const { isSelected, item, onSelect, sx } = props;
-    const { icon, label } = item;
+    const { icon, isSelected, label, onSelect, sx, value, ...rest } = props;
 
     const handleClick = useCallback<MouseEventHandler<HTMLElement>>(
       e => {
-        onSelect?.(item, e);
+        onSelect?.(value, e);
       },
-      [item, onSelect],
+      [onSelect, value],
     );
 
     return (
@@ -51,6 +59,7 @@ export const NavigationItem = forwardRef<HTMLLIElement, NavigationItemProps>(
           },
           sx,
         )}
+        {...rest}
       >
         <MotionBox
           animate={{ scale: isSelected ? 1 : 0.8 }}

--- a/src/components/NavigationItem.tsx
+++ b/src/components/NavigationItem.tsx
@@ -16,7 +16,7 @@ import { Text } from './Text';
 export interface NavigationItemItem {
   icon: ReactElement;
   label?: string;
-  name: string;
+  value: string;
 }
 
 export interface NavigationItemProps extends Omit<BoxProps<'li'>, 'onSelect'> {

--- a/src/components/NavigationItem.tsx
+++ b/src/components/NavigationItem.tsx
@@ -32,11 +32,9 @@ export const NavigationItem = forwardRef<HTMLLIElement, NavigationItemProps>(
 
     const handleClick = useCallback<MouseEventHandler<HTMLElement>>(
       e => {
-        if (isSelected) return;
-
         onSelect?.(item, e);
       },
-      [isSelected, item, onSelect],
+      [item, onSelect],
     );
 
     return (

--- a/src/components/NavigationRail.tsx
+++ b/src/components/NavigationRail.tsx
@@ -7,32 +7,26 @@ import { Stack } from './Stack';
 
 export interface NavigationRailProps extends BoxProps<'nav'> {
   items?: NavigationItemItem[];
-  onSelectedNameChange: (name: string, e: MouseEvent<HTMLElement>) => void;
-  selectedName?: string;
+  onValueChange: (value: string, e: MouseEvent<HTMLElement>) => void;
+  value?: string;
 }
 
 export const NavigationRail = forwardRef<HTMLElement, NavigationRailProps>(
   function NavigationRail(props, ref) {
-    const {
-      items = [],
-      onSelectedNameChange,
-      selectedName,
-      sx,
-      ...rest
-    } = props;
+    const { items = [], onValueChange, sx, value, ...rest } = props;
 
     const getIsSelected = useCallback<(item: NavigationItemItem) => boolean>(
-      ({ name }) => name === selectedName,
-      [selectedName],
+      item => item.value === value,
+      [value],
     );
 
     const handleItemSelect = useCallback<
       (item: NavigationItemItem, e: MouseEvent<HTMLElement>) => void
     >(
-      ({ name }, e) => {
-        onSelectedNameChange(name, e);
+      (item, e) => {
+        onValueChange(item.value, e);
       },
-      [onSelectedNameChange],
+      [onValueChange],
     );
 
     return (

--- a/src/components/NavigationRail.tsx
+++ b/src/components/NavigationRail.tsx
@@ -2,29 +2,35 @@ import React, { forwardRef, MouseEvent, useCallback } from 'react';
 
 import { mergeSX } from '../helpers';
 import { Box, BoxProps } from './Box';
-import { NavigationItem, NavigationItemItem } from './NavigationItem';
+import {
+  NavigationItem,
+  NavigationItemItem,
+  NavigationItemOnSelect,
+  NavigationItemValue,
+} from './NavigationItem';
 import { Stack } from './Stack';
 
 export interface NavigationRailProps extends BoxProps<'nav'> {
   items?: NavigationItemItem[];
-  onValueChange: (value: string, e: MouseEvent<HTMLElement>) => void;
-  value?: string;
+  onValueChange: (
+    value: NavigationItemValue,
+    e: MouseEvent<HTMLElement>,
+  ) => void;
+  value?: NavigationItemValue;
 }
 
 export const NavigationRail = forwardRef<HTMLElement, NavigationRailProps>(
   function NavigationRail(props, ref) {
     const { items = [], onValueChange, sx, value, ...rest } = props;
 
-    const getIsSelected = useCallback<(item: NavigationItemItem) => boolean>(
-      item => item.value === value,
+    const getIsSelected = useCallback<(item: NavigationItemValue) => boolean>(
+      itemValue => itemValue === value,
       [value],
     );
 
-    const handleItemSelect = useCallback<
-      (item: NavigationItemItem, e: MouseEvent<HTMLElement>) => void
-    >(
-      (item, e) => {
-        onValueChange(item.value, e);
+    const handleItemSelect = useCallback<NavigationItemOnSelect>(
+      (selectedValue, e) => {
+        onValueChange(selectedValue, e);
       },
       [onValueChange],
     );
@@ -48,10 +54,15 @@ export const NavigationRail = forwardRef<HTMLElement, NavigationRailProps>(
         <Stack as="ul">
           {items.map((item, index) => (
             <NavigationItem
-              isSelected={getIsSelected(item)}
-              item={item}
+              icon={item.icon}
+              label={item.label}
+              isSelected={getIsSelected(item.value)}
               key={`${item.label}${index}`}
               onSelect={handleItemSelect}
+              sx={{
+                label: 'NavigationRailItem',
+              }}
+              value={item.value}
             />
           ))}
         </Stack>

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -74,7 +74,7 @@ export const RadioButton = forwardRef<HTMLDivElement, RadioButtonProps>(
           {
             cursor: disabled ? 'not-allowed' : 'pointer',
             label: 'RadioButton',
-            opacity: disabled ? 0.5 : 1,
+            opacity: disabled ? theme.disabledOpacity : undefined,
             outline: 'none',
           },
           sx,

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -99,6 +99,7 @@ export const RadioGroup = forwardRef<HTMLElement, RadioGroupProps>(
 
     return (
       <FormGroup
+        disabled={disabled}
         element="div"
         onKeyDown={handleKeyDown}
         ref={ref}
@@ -106,7 +107,6 @@ export const RadioGroup = forwardRef<HTMLElement, RadioGroupProps>(
         sx={mergeSX(
           {
             label: 'RadioGroup',
-            opacity: disabled ? 0.5 : 1,
           },
           sx,
         )}

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -82,6 +82,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 
     return (
       <FormGroup
+        disabled={disabled}
         error={error}
         label={label}
         space={3}
@@ -91,7 +92,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           {
             appearance: 'none',
             label: 'Select',
-            opacity: disabled ? 0.5 : 1,
             width: '100%',
           },
           sx,
@@ -103,6 +103,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           sx={{
             alignItems: 'center',
             display: 'flex',
+            opacity: disabled ? theme.disabledOpacity : undefined,
             position: 'relative',
           }}
         >

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, MouseEvent, MouseEventHandler } from 'react';
 
 import { mergeSX } from '../helpers';
+import { useThemeWithDefault } from '../hooks';
 import { Box, BoxProps } from './Box';
 import { MotionBox } from './MotionBox';
 import { Text } from './Text';
@@ -23,6 +24,7 @@ export const Tab = forwardRef<HTMLDivElement, TabProps>(function Tab(
   ref,
 ) {
   const { disabled, isSelected, label, onSelect, sx, value, ...rest } = props;
+  const theme = useThemeWithDefault();
 
   const handleClick: MouseEventHandler<HTMLDivElement> = e => {
     if (disabled || isSelected) return;
@@ -47,7 +49,7 @@ export const Tab = forwardRef<HTMLDivElement, TabProps>(function Tab(
           display: 'flex',
           flexShrink: 0,
           label: 'Tab',
-          opacity: disabled ? 0.5 : 1,
+          opacity: disabled ? theme.disabledOpacity : undefined,
           position: 'relative',
         },
         sx,

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -88,6 +88,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     return (
       <FormGroup
+        disabled={disabled}
         error={error}
         htmlFor={id}
         label={label}
@@ -97,7 +98,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         sx={mergeSX(
           {
             label: 'TextField',
-            opacity: disabled ? 0.5 : 1,
             width: '100%',
           },
           sx,
@@ -109,6 +109,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           sx={{
             alignItems: 'center',
             display: 'flex',
+            opacity: disabled ? theme.disabledOpacity : undefined,
             position: 'relative',
             width: '100%',
           }}

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -75,7 +75,7 @@ export const Toggle = forwardRef<HTMLDivElement, ToggleProps>(function Toggle(
         {
           cursor: disabled ? 'not-allowed' : 'pointer',
           label: 'Toggle',
-          opacity: disabled ? 0.5 : 1,
+          opacity: disabled ? theme.disabledOpacity : undefined,
           outline: 'none',
         },
         sx,

--- a/src/themes/darkTheme.ts
+++ b/src/themes/darkTheme.ts
@@ -14,4 +14,5 @@ export const darkTheme = createTheme({
     textSecondary: '#9696b6',
     warning: '#febb3f',
   },
+  disabledOpacity: 0.5,
 });

--- a/src/themes/lightTheme.ts
+++ b/src/themes/lightTheme.ts
@@ -14,4 +14,5 @@ export const lightTheme = createTheme({
     textSecondary: '#646487',
     warning: '#febb3f',
   },
+  disabledOpacity: 0.5,
 });

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -62,8 +62,11 @@ export interface ThemeColors {
   warning: CSS.Properties['color'];
 }
 
-export interface Theme extends ThemeBase {
+export interface ThemeDetails {
   colors: ThemeColors;
+  disabledOpacity: number;
 }
 
-export type ThemeOptions = RecursivePartial<Theme> & { colors: ThemeColors };
+export type Theme = ThemeBase & ThemeDetails;
+
+export type ThemeOptions = RecursivePartial<ThemeBase> & ThemeDetails;

--- a/stories/Components/BottomNavigation.stories.tsx
+++ b/stories/Components/BottomNavigation.stories.tsx
@@ -26,7 +26,11 @@ export default {
   ],
   argTypes: {
     items: { table: { disable: true } },
-    onSelectedNameChange: { action: 'onSelectedNameChange' },
+    onValueChange: { action: 'onValueChange' },
+    value: {
+      control: { type: 'inline-radio' },
+      options: [undefined, 'home', 'likes', 'profile'],
+    },
   },
   parameters: {
     layout: 'fullscreen',
@@ -39,18 +43,11 @@ export const Default: Story<BottomNavigationProps> = args => (
 
 Default.args = {
   items: [
-    { icon: <HomeIcon />, label: 'Home', name: 'home' },
-    { icon: <HeartIcon />, label: 'Likes', name: 'likes' },
-    { icon: <AccountBoxIcon />, label: 'Profile', name: 'profile' },
+    { icon: <HomeIcon />, label: 'Home', value: 'home' },
+    { icon: <HeartIcon />, label: 'Likes', value: 'likes' },
+    { icon: <AccountBoxIcon />, label: 'Profile', value: 'profile' },
   ],
-  selectedName: 'home',
-};
-
-Default.argTypes = {
-  selectedName: {
-    control: { type: 'inline-radio' },
-    options: [undefined, 'home', 'likes', 'profile'],
-  },
+  value: 'home',
 };
 
 Default.parameters = {

--- a/stories/Components/FormGroup.stories.tsx
+++ b/stories/Components/FormGroup.stories.tsx
@@ -1,0 +1,84 @@
+import { Meta, Story } from '@storybook/react';
+import React from 'react';
+
+import { FormGroup, FormGroupProps } from '../../src';
+
+export default {
+  title: 'Components/FormGroup',
+  component: FormGroup,
+  argTypes: {
+    error: { control: { type: 'text' } },
+    label: { control: { type: 'text' } },
+    secondaryLabel: { control: { type: 'text' } },
+    success: { control: { type: 'text' } },
+    warning: { control: { type: 'text' } },
+  },
+} as Meta;
+
+export const Default: Story<FormGroupProps> = args => (
+  <FormGroup {...args}>
+    <span>Content</span>
+  </FormGroup>
+);
+
+Default.args = {
+  disabled: false,
+  label: 'Label',
+};
+
+export const Disabled: Story<FormGroupProps> = args => (
+  <FormGroup {...args}>
+    <span>Content</span>
+  </FormGroup>
+);
+
+Disabled.args = {
+  ...Default.args,
+  disabled: true,
+  error: 'Error message',
+  secondaryLabel: 'Secondary label',
+};
+
+export const WithError: Story<FormGroupProps> = args => (
+  <FormGroup {...args}>
+    <span>Content</span>
+  </FormGroup>
+);
+
+WithError.args = {
+  ...Default.args,
+  error: 'Error message',
+};
+
+export const WithSecondaryLabel: Story<FormGroupProps> = args => (
+  <FormGroup {...args}>
+    <span>Content</span>
+  </FormGroup>
+);
+
+WithSecondaryLabel.args = {
+  ...Default.args,
+  secondaryLabel: 'Secondary label',
+};
+
+export const WithSuccess: Story<FormGroupProps> = args => (
+  <FormGroup {...args}>
+    <span>Content</span>
+  </FormGroup>
+);
+
+WithSuccess.args = {
+  ...Default.args,
+  success: 'Success message',
+};
+
+export const WithWarning: Story<FormGroupProps> = args => (
+  <FormGroup {...args}>
+    <span>Content</span>
+  </FormGroup>
+);
+
+WithWarning.args = {
+  ...Default.args,
+  warning: 'Warning message',
+};

--- a/stories/Components/NavigationItem.stories.tsx
+++ b/stories/Components/NavigationItem.stories.tsx
@@ -21,3 +21,12 @@ Default.args = {
   isSelected: false,
   item: { icon: <AccountBoxIcon />, label: 'Profile', name: 'profile' },
 };
+
+export const Selected: Story<NavigationItemProps> = args => (
+  <NavigationItem {...args} />
+);
+
+Selected.args = {
+  ...Default.args,
+  isSelected: true,
+};

--- a/stories/Components/NavigationItem.stories.tsx
+++ b/stories/Components/NavigationItem.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/NavigationItem',
   component: NavigationItem,
   argTypes: {
-    item: { table: { disable: true } },
+    icon: { table: { disable: true } },
     onSelect: { action: 'onSelect' },
   },
 } as Meta;
@@ -18,8 +18,10 @@ export const Default: Story<NavigationItemProps> = args => (
 );
 
 Default.args = {
+  icon: <AccountBoxIcon />,
   isSelected: false,
-  item: { icon: <AccountBoxIcon />, label: 'Profile', name: 'profile' },
+  label: 'Profile',
+  value: 'profile',
 };
 
 export const Selected: Story<NavigationItemProps> = args => (

--- a/stories/Components/NavigationRail.stories.tsx
+++ b/stories/Components/NavigationRail.stories.tsx
@@ -24,7 +24,11 @@ export default {
   ],
   argTypes: {
     items: { table: { disable: true } },
-    onSelectedNameChange: { action: 'onSelectedNameChange' },
+    onValueChange: { action: 'onValueChange' },
+    value: {
+      control: { type: 'inline-radio' },
+      options: [undefined, 'home', 'likes', 'profile'],
+    },
   },
   parameters: {
     layout: 'fullscreen',
@@ -37,16 +41,9 @@ export const Default: Story<NavigationRailProps> = args => (
 
 Default.args = {
   items: [
-    { icon: <HomeIcon />, label: 'Home', name: 'home' },
-    { icon: <HeartIcon />, label: 'Likes', name: 'likes' },
-    { icon: <AccountBoxIcon />, label: 'Profile', name: 'profile' },
+    { icon: <HomeIcon />, label: 'Home', value: 'home' },
+    { icon: <HeartIcon />, label: 'Likes', value: 'likes' },
+    { icon: <AccountBoxIcon />, label: 'Profile', value: 'profile' },
   ],
-  selectedName: 'home',
-};
-
-Default.argTypes = {
-  selectedName: {
-    control: { type: 'inline-radio' },
-    options: [undefined, 'home', 'likes', 'profile'],
-  },
+  value: 'home',
 };

--- a/test/components/BottomNavigation.test.tsx
+++ b/test/components/BottomNavigation.test.tsx
@@ -9,28 +9,22 @@ const { Default } = composeStories(stories);
 
 describe('BottomNavigation', () => {
   test('should allow selecting an item', () => {
-    const handleSelectedNameChange = jest.fn();
+    const handleValueChange = jest.fn();
 
-    render(<Default onSelectedNameChange={handleSelectedNameChange} />);
+    render(<Default onValueChange={handleValueChange} />);
 
     userEvent.click(screen.getByText('Likes'));
 
-    expect(handleSelectedNameChange).toHaveBeenCalledWith(
-      'likes',
-      expect.any(Object),
-    );
+    expect(handleValueChange).toHaveBeenCalledWith('likes', expect.any(Object));
   });
 
   test('should still allow selecting a selected item', () => {
-    const handleSelectedNameChange = jest.fn();
+    const handleValueChange = jest.fn();
 
-    render(<Default onSelectedNameChange={handleSelectedNameChange} />);
+    render(<Default onValueChange={handleValueChange} />);
 
     userEvent.click(screen.getByText('Home'));
 
-    expect(handleSelectedNameChange).toHaveBeenCalledWith(
-      'home',
-      expect.any(Object),
-    );
+    expect(handleValueChange).toHaveBeenCalledWith('home', expect.any(Object));
   });
 });

--- a/test/components/BottomNavigation.test.tsx
+++ b/test/components/BottomNavigation.test.tsx
@@ -21,13 +21,16 @@ describe('BottomNavigation', () => {
     );
   });
 
-  test('should not allow selecting a selected item', () => {
+  test('should still allow selecting a selected item', () => {
     const handleSelectedNameChange = jest.fn();
 
     render(<Default onSelectedNameChange={handleSelectedNameChange} />);
 
     userEvent.click(screen.getByText('Home'));
 
-    expect(handleSelectedNameChange).not.toHaveBeenCalled();
+    expect(handleSelectedNameChange).toHaveBeenCalledWith(
+      'home',
+      expect.any(Object),
+    );
   });
 });

--- a/test/components/NavigationItem.test.tsx
+++ b/test/components/NavigationItem.test.tsx
@@ -1,0 +1,38 @@
+import { composeStories } from '@storybook/testing-react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { render, screen } from '../../src/testUtils';
+import * as stories from '../../stories/Components/NavigationItem.stories';
+
+const { Default, Selected } = composeStories(stories);
+
+describe('NavigationItem', () => {
+  test('should allow selection by default', () => {
+    const handleSelect = jest.fn();
+
+    render(<Default onSelect={handleSelect} />);
+
+    userEvent.click(screen.getByText('Profile'));
+
+    expect(handleSelect).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+    );
+    // expect(handleSelect).toHaveBeenCalledWith('profile', expect.any(Object));
+  });
+
+  test('should still allow selection when selected', () => {
+    const handleSelect = jest.fn();
+
+    render(<Selected onSelect={handleSelect} />);
+
+    userEvent.click(screen.getByText('Profile'));
+
+    expect(handleSelect).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+    );
+    // expect(handleSelect).toHaveBeenCalledWith('profile', expect.any(Object));
+  });
+});

--- a/test/components/NavigationItem.test.tsx
+++ b/test/components/NavigationItem.test.tsx
@@ -15,11 +15,7 @@ describe('NavigationItem', () => {
 
     userEvent.click(screen.getByText('Profile'));
 
-    expect(handleSelect).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.any(Object),
-    );
-    // expect(handleSelect).toHaveBeenCalledWith('profile', expect.any(Object));
+    expect(handleSelect).toHaveBeenCalledWith('profile', expect.any(Object));
   });
 
   test('should still allow selection when selected', () => {
@@ -29,10 +25,6 @@ describe('NavigationItem', () => {
 
     userEvent.click(screen.getByText('Profile'));
 
-    expect(handleSelect).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.any(Object),
-    );
-    // expect(handleSelect).toHaveBeenCalledWith('profile', expect.any(Object));
+    expect(handleSelect).toHaveBeenCalledWith('profile', expect.any(Object));
   });
 });

--- a/test/components/NavigationRail.test.tsx
+++ b/test/components/NavigationRail.test.tsx
@@ -21,13 +21,16 @@ describe('NavigationRail', () => {
     );
   });
 
-  test('should not allow selecting a selected item', () => {
+  test('should still allow selecting a selected item', () => {
     const handleSelectedNameChange = jest.fn();
 
     render(<Default onSelectedNameChange={handleSelectedNameChange} />);
 
     userEvent.click(screen.getByText('Home'));
 
-    expect(handleSelectedNameChange).not.toHaveBeenCalled();
+    expect(handleSelectedNameChange).toHaveBeenCalledWith(
+      'home',
+      expect.any(Object),
+    );
   });
 });

--- a/test/components/NavigationRail.test.tsx
+++ b/test/components/NavigationRail.test.tsx
@@ -9,28 +9,22 @@ const { Default } = composeStories(stories);
 
 describe('NavigationRail', () => {
   test('should allow selecting an item', () => {
-    const handleSelectedNameChange = jest.fn();
+    const handleValueChange = jest.fn();
 
-    render(<Default onSelectedNameChange={handleSelectedNameChange} />);
+    render(<Default onValueChange={handleValueChange} />);
 
     userEvent.click(screen.getByText('Likes'));
 
-    expect(handleSelectedNameChange).toHaveBeenCalledWith(
-      'likes',
-      expect.any(Object),
-    );
+    expect(handleValueChange).toHaveBeenCalledWith('likes', expect.any(Object));
   });
 
   test('should still allow selecting a selected item', () => {
-    const handleSelectedNameChange = jest.fn();
+    const handleValueChange = jest.fn();
 
-    render(<Default onSelectedNameChange={handleSelectedNameChange} />);
+    render(<Default onValueChange={handleValueChange} />);
 
     userEvent.click(screen.getByText('Home'));
 
-    expect(handleSelectedNameChange).toHaveBeenCalledWith(
-      'home',
-      expect.any(Object),
-    );
+    expect(handleValueChange).toHaveBeenCalledWith('home', expect.any(Object));
   });
 });


### PR DESCRIPTION
- feat: First class disabled support in FormGroup
- fix: Navigation Item should still be selectable when selected
- BREAKING CHANGE: NavigationItemItem name -> value
- refactor: Spread out NavigationItem props